### PR TITLE
changed the span creation from creation via decorator to creaion via …

### DIFF
--- a/TelemetryConfig/common_commands.md
+++ b/TelemetryConfig/common_commands.md
@@ -23,6 +23,16 @@ docker run --rm \
   jaegertracing/all-in-one:latest
 ```
 
+```powershell
+docker run --rm `
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 `
+  -p 16686:16686 `
+  -p 4317:4317 `
+  -p 4318:4318 `
+  -p 9411:9411 `
+  jaegertracing/all-in-one:latest
+```
+
 **Running prometheus inside a container**
 
 ```bash

--- a/dependencies/editorjs_data_store.py
+++ b/dependencies/editorjs_data_store.py
@@ -15,7 +15,7 @@ from opentelemetry.trace import Status, StatusCode
 
 tracer = trace.get_tracer(__name__)
 
-@tracer.start_as_current_span("add_tool_md")
+# @tracer.start_as_current_span("add_tool_md")
 def add_tool_md(session: Session,
                 block: Block,
                 article_id: uuid.UUID,
@@ -25,33 +25,36 @@ def add_tool_md(session: Session,
                     Session, tool_model.ToolMD
                 ]:
     current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_tool_md"
-    ))
-    current_span.set_attribute("article.id", str(article_id))
-    current_span.set_attribute("version", version)
-    current_span.set_attribute("time", str(time))
-    tool_id = session.exec(
-        select(tool_model.Tool)
-        .where(tool_model.Tool.name == block.type)
-    ).one().id 
-    tool_md = tool_model.ToolMD(
-        sequence= block.sequence,
-        article_id= article_id,
-        block_id= block.id,
-        tool_id= tool_id,
-        time= time,
-        version=version
-    )
-    session.add(tool_md)
-    # print(f"created tool: {tool_md}")
-    logger.info(f"successfully created tool_md: {tool_md}")
+    with tracer.start_as_current_span("add_tool_md", 
+                                      attributes={
+                                          **origination_(
+                                              package="dependencies",
+                                              module="editorjs_data_store",
+                                              func_name="add_tool_md"
+                                          ),
+                                          "article.id": str(article_id),
+                                          "version": version,
+                                          "time": str(time)
+                                      }) as current_span:
+        tool_id = session.exec(
+            select(tool_model.Tool)
+            .where(tool_model.Tool.name == block.type)
+        ).one().id 
+        tool_md = tool_model.ToolMD(
+            sequence= block.sequence,
+            article_id= article_id,
+            block_id= block.id,
+            tool_id= tool_id,
+            time= time,
+            version=version
+        )
+        session.add(tool_md)
+        # print(f"created tool: {tool_md}")
+        logger.info(f"successfully created tool_md: {tool_md}")
     return (session, tool_md)
 
 # create individual functions for adding record to the db
-@tracer.start_as_current_span("add_code_tool_data")
+# @tracer.start_as_current_span("add_code_tool_data")
 def add_code_tool_data(session: Session, 
                        block: Block, 
                        tool_md_id: uuid.UUID
@@ -59,28 +62,31 @@ def add_code_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_code_tool_data"
-                                ))
-    current_span.set_attribute("tool_md_id", str(tool_md_id))
-    if type(block.data) != CodeToolData:
-        raise ValueError(f"object of CodeToolData class was expected but instead got {type(block.data)}")
-    
-    ct_tbl = code_tool_model.CodeTool(
-        code= block.data.code,
-        language_code= block.data.languageCode,
-        tool_md_id= tool_md_id
-    )
-    session.add(ct_tbl)
-    session.commit()
-    current_span.add_event("code_tool_data has been added into the db table")
+    # current_span = trace.get_current_span()
+    with tracer.start_as_current_span("add_code_tool_data",
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="add_code_tool_data"
+                                            ),
+                                            "tool_md_id": str(tool_md_id)
+                                      }) as current_span:
+        if type(block.data) != CodeToolData:
+            raise ValueError(f"object of CodeToolData class was expected but instead got {type(block.data)}")
+
+        ct_tbl = code_tool_model.CodeTool(
+            code= block.data.code,
+            language_code= block.data.languageCode,
+            tool_md_id= tool_md_id
+        )
+        session.add(ct_tbl)
+        session.commit()
+        current_span.add_event("code_tool_data has been added into the db table")
     return (session, ct_tbl)
 
 
-@tracer.start_as_current_span("add_header_tool_data")
+# @tracer.start_as_current_span("add_header_tool_data")
 def add_header_tool_data(session: Session, 
                        block: Block, 
                        tool_md_id: uuid.UUID
@@ -88,28 +94,37 @@ def add_header_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_header_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
-    if type(block.data) != HeaderData:
-        raise ValueError(f"object of HeaderData class was expected but instead got {type(block.data)}")
-    
-    ht_tbl = header_tool_model.HeaderTool(
-        text= block.data.text,
-        level= block.data.level,
-        tool_md_id=tool_md_id
-    )
-    session.add(ht_tbl)
-    session.commit()
-    current_span.add_event("header tool data has been inserted into db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="add_header_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
+    with tracer.start_as_current_span("add_header_tool_data",
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="add_header_tool_data"
+                                            ),
+                                            "tool_md.id": str(tool_md_id)
+                                      }) as current_span:
+        if type(block.data) != HeaderData:
+            raise ValueError(f"object of HeaderData class was expected but instead got {type(block.data)}")
+
+        ht_tbl = header_tool_model.HeaderTool(
+            text= block.data.text,
+            level= block.data.level,
+            tool_md_id=tool_md_id
+        )
+        session.add(ht_tbl)
+        session.commit()
+        current_span.add_event("header tool data has been inserted into db")
     return (session, ht_tbl)
 
 
-@tracer.start_as_current_span("add_list_tool_data")
+# @tracer.start_as_current_span("add_list_tool_data")
 def add_list_tool_data(session: Session, 
                        block: Block, 
                        tool_md_id: uuid.UUID
@@ -117,54 +132,65 @@ def add_list_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_list_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="add_list_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
     
-    if type(block.data) != ListData:
-        raise ValueError(f"object of ListData class was expected but instead got {type(block.data)}")
+    with tracer.start_as_current_span("add_list_tool_data",
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="add_list_tool_data"
+                                            ),
+                                            "tool_md.id": str(tool_md_id)
+                                      }
+                                      ) as current_span:
 
-    @tracer.start_as_current_span("store_items")
-    def store_items(session: Session, 
-                   item_list: List[ListItem],
-                   lttbl_id: Optional[uuid.UUID],
-                   parent_item_id: Optional[uuid.UUID]):
-        current_span = trace.get_current_span()
-        for idx, item in enumerate(item_list):
-            sequence = idx + 1
-            item_tbl = list_tool_models.Item(
-                lttbl_id= lttbl_id,
-                sequence= sequence,
-                content= item.content,
-                meta= item.meta,
-                parent_item_id= parent_item_id
-            )
-            session.add(item_tbl)
-            if item.items != []:
-                store_items(session, item.items, None, item_tbl.id)
-        current_span.add_event("list items have been inserted in item tbl")
+        if type(block.data) != ListData:
+            raise ValueError(f"object of ListData class was expected but instead got {type(block.data)}")
+
+        @tracer.start_as_current_span("store_items")
+        def store_items(session: Session, 
+                       item_list: List[ListItem],
+                       lttbl_id: Optional[uuid.UUID],
+                       parent_item_id: Optional[uuid.UUID]):
+            current_span = trace.get_current_span()
+            for idx, item in enumerate(item_list):
+                sequence = idx + 1
+                item_tbl = list_tool_models.Item(
+                    lttbl_id= lttbl_id,
+                    sequence= sequence,
+                    content= item.content,
+                    meta= item.meta,
+                    parent_item_id= parent_item_id
+                )
+                session.add(item_tbl)
+                if item.items != []:
+                    store_items(session, item.items, None, item_tbl.id)
+            current_span.add_event("list items have been inserted in item tbl")
 
 
-    lt_tbl = list_tool_models.ListToolTbl(
-        style= block.data.style,
-        meta= block.data.meta,
-        tool_md_id= tool_md_id
-    )
+        lt_tbl = list_tool_models.ListToolTbl(
+            style= block.data.style,
+            meta= block.data.meta,
+            tool_md_id= tool_md_id
+        )
 
-    session.add(lt_tbl)
-    store_items(session, block.data.items,
-                lt_tbl.id,
-                None)
-    session.commit()
-    current_span.add_event("list tool data has been inserted in the list tool tbl")
+        session.add(lt_tbl)
+        store_items(session, block.data.items,
+                    lt_tbl.id,
+                    None)
+        session.commit()
+        current_span.add_event("list tool data has been inserted in the list tool tbl")
     return (session, lt_tbl)
 
 
-@tracer.start_as_current_span("add_paragraph_tool_data")
+# @tracer.start_as_current_span("add_paragraph_tool_data")
 def add_paragraph_tool_data(session: Session, 
                        block: Block, 
                        tool_md_id: uuid.UUID
@@ -172,32 +198,41 @@ def add_paragraph_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_paragraph_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="add_paragraph_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
 
-    if type(block.data) != ParagraphData:
-        raise ValueError(f"object of ParagraphData class was expected but instead got {type(block.data)}")
-    
-    if type(tool_md_id) != uuid.UUID:
-        ValueError(f"tool md is not of uuid type : {tool_md_id}")
+    with tracer.start_as_current_span("add_paragraph_tool_data", 
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="add_paragraph_tool_data"
+                                            ),
+                                            "tool_md.id": str(tool_md_id)
+                                      }) as current_span:
+        if type(block.data) != ParagraphData:
+            raise ValueError(f"object of ParagraphData class was expected but instead got {type(block.data)}")
 
-    p_tbl = paragraph_tool_model.ParagraphTool(
-        text= block.data.text,
-        tool_md_id= tool_md_id
-    )
+        if type(tool_md_id) != uuid.UUID:
+            ValueError(f"tool md is not of uuid type : {tool_md_id}")
 
-    session.add(p_tbl)
-    session.commit()
-    current_span.add_event("paragraph tool data has been inserted into the paragraph tool tbl")
+        p_tbl = paragraph_tool_model.ParagraphTool(
+            text= block.data.text,
+            tool_md_id= tool_md_id
+        )
+
+        session.add(p_tbl)
+        session.commit()
+        current_span.add_event("paragraph tool data has been inserted into the paragraph tool tbl")
     return (session, p_tbl)
 
 
-@tracer.start_as_current_span("add_quote_tool_data")
+# @tracer.start_as_current_span("add_quote_tool_data")
 def add_quote_tool_data(session: Session, 
                        block: Block, 
                        tool_md_id: uuid.UUID
@@ -205,29 +240,38 @@ def add_quote_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_quote_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
-    if type(block.data) != QuoteData:
-        raise ValueError(f"object of QuoteData class was expected but instead got {type(block.data)}")
-    
-    q_tbl = quote_tool_model.QuoteTool(
-        text= block.data.text,
-        caption= block.data.caption,
-        alignment= block.data.alignment,
-        tool_md_id= tool_md_id
-    )
-    session.add(q_tbl)
-    session.commit()
-    current_span.add_event("quote tool data has been inserted into the quote tool tbl")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="add_quote_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
+    with tracer.start_as_current_span("add_quote_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="add_quote_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md_id)
+                                      }) as current_span:
+        if type(block.data) != QuoteData:
+            raise ValueError(f"object of QuoteData class was expected but instead got {type(block.data)}")
+
+        q_tbl = quote_tool_model.QuoteTool(
+            text= block.data.text,
+            caption= block.data.caption,
+            alignment= block.data.alignment,
+            tool_md_id= tool_md_id
+        )
+        session.add(q_tbl)
+        session.commit()
+        current_span.add_event("quote tool data has been inserted into the quote tool tbl")
     return (session, q_tbl)
 
 
-@tracer.start_as_current_span("add_table_tool_data")
+# @tracer.start_as_current_span("add_table_tool_data")
 def add_table_tool_data(session: Session, 
                        block: Block, 
                        tool_md_id: uuid.UUID
@@ -235,27 +279,36 @@ def add_table_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="add_table_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
-    if type(block.data) != TableData:
-        raise ValueError(f"object of TableData class was expected but instead got {type(block.data)}")
-    
-    tt_tbl = table_tool_model.TableTool(
-        content= block.data.content,
-        tool_md_id= tool_md_id
-    )
-    session.add(tt_tbl)
-    session.commit()
-    current_span.add_event("table tool data has been inserted into the table_tool tbl")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="add_table_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
+    with tracer.start_as_current_span("add_table_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="add_table_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md_id)
+                                      }) as current_span:
+        if type(block.data) != TableData:
+            raise ValueError(f"object of TableData class was expected but instead got {type(block.data)}")
+
+        tt_tbl = table_tool_model.TableTool(
+            content= block.data.content,
+            tool_md_id= tool_md_id
+        )
+        session.add(tt_tbl)
+        session.commit()
+        current_span.add_event("table tool data has been inserted into the table_tool tbl")
     return (session, tt_tbl)
 
 
-@tracer.start_as_current_span("update_ToolMD")
+# @tracer.start_as_current_span("update_ToolMD")
 def update_ToolMD(session: Session, 
                           tool_md: tool_model.ToolMD,
                           tool_name: str,
@@ -263,21 +316,30 @@ def update_ToolMD(session: Session,
                               Session,
                               tool_model.ToolMD
                           ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_ToolMD"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    new_tool_id = session.exec(
-        select(tool_model.Tool)
-        .where(tool_model.Tool.name == tool_name)
-    ).one().id
-    tool_md.tool_id = new_tool_id
-    tool_md.block_id = block_id
-    session.add(tool_md)
-    current_span.add_event("tool_md table has been updated in the db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_ToolMD"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_ToolMD",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_ToolMD"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        new_tool_id = session.exec(
+            select(tool_model.Tool)
+            .where(tool_model.Tool.name == tool_name)
+        ).one().id
+        tool_md.tool_id = new_tool_id
+        tool_md.block_id = block_id
+        session.add(tool_md)
+        current_span.add_event("tool_md table has been updated in the db")
     return (session, tool_md)
 
 
@@ -294,7 +356,7 @@ here already available tool_md's id is given.
 if block.type is CodeToolData then call this func.
 '''
 # create individual functions for updating record in the db
-@tracer.start_as_current_span("update_code_tool_data")
+# @tracer.start_as_current_span("update_code_tool_data")
 def update_code_tool_data(session: Session, 
                        block: Block, 
                        tool_md: tool_model.ToolMD
@@ -302,57 +364,66 @@ def update_code_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_code_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    if type(block.data) != CodeToolData:
-        raise ValueError(f"object of CodeToolData class was expected but instead got {type(block.data)}")
-    
-    tool_name = tool_md.tool.name
-    if tool_name == block.type:
-        ct_tbl = session.exec(
-            select(code_tool_model.CodeTool)
-            .where(code_tool_model.CodeTool.tool_md_id == tool_md.id)
-        ).one()
-        ct_tbl.code = block.data.code
-        ct_tbl.language_code = block.data.languageCode
-        session.add(ct_tbl)
-        session.commit()
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_code_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_code_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_code_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        if type(block.data) != CodeToolData:
+            raise ValueError(f"object of CodeToolData class was expected but instead got {type(block.data)}")
 
-    else:
-        tool_cls = tool_name_cls_map[tool_name]
-        tool_inst = session.exec(
-            select(tool_cls)
-            .where(tool_cls.tool_md_id == tool_md.id)
-        ).one()
-        session.delete(tool_inst)
+        tool_name = tool_md.tool.name
+        if tool_name == block.type:
+            ct_tbl = session.exec(
+                select(code_tool_model.CodeTool)
+                .where(code_tool_model.CodeTool.tool_md_id == tool_md.id)
+            ).one()
+            ct_tbl.code = block.data.code
+            ct_tbl.language_code = block.data.languageCode
+            session.add(ct_tbl)
+            session.commit()
 
-        # ct_tbl = code_tool_model.CodeTool(
-        #     code= block.data.code,
-        #     language_code= block.data.languageCode,
-        #     tool_md_id= tool_md.id
-        # )        
-        # session.add(ct_tbl)
-        session, tool_md = update_ToolMD(session=session,
-                                                 tool_md= tool_md,
-                                                 tool_name= block.type,
-                                                 block_id=block.id)
-        
-        # raise ValueError(f"{tool_md}")
-        session, ct_tbl = add_code_tool_data(session, 
-                           block=block, 
-                           tool_md_id= tool_md.id
-                           )
+        else:
+            tool_cls = tool_name_cls_map[tool_name]
+            tool_inst = session.exec(
+                select(tool_cls)
+                .where(tool_cls.tool_md_id == tool_md.id)
+            ).one()
+            session.delete(tool_inst)
 
-    current_span.add_event("code tool data has been updated in the code tool tbl")
+            # ct_tbl = code_tool_model.CodeTool(
+            #     code= block.data.code,
+            #     language_code= block.data.languageCode,
+            #     tool_md_id= tool_md.id
+            # )        
+            # session.add(ct_tbl)
+            session, tool_md = update_ToolMD(session=session,
+                                                     tool_md= tool_md,
+                                                     tool_name= block.type,
+                                                     block_id=block.id)
+
+            # raise ValueError(f"{tool_md}")
+            session, ct_tbl = add_code_tool_data(session, 
+                               block=block, 
+                               tool_md_id= tool_md.id
+                               )
+
+        current_span.add_event("code tool data has been updated in the code tool tbl")
     return (session, ct_tbl)
 
 
-@tracer.start_as_current_span("update_header_tool_data")
+# @tracer.start_as_current_span("update_header_tool_data")
 def update_header_tool_data(session: Session, 
                        block: Block, 
                        tool_md: tool_model.ToolMD
@@ -360,58 +431,67 @@ def update_header_tool_data(session: Session,
                            Session,
                            tool_model.ToolDataModel
                            ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_header_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    if type(block.data) != HeaderData:
-        raise ValueError(f"object of HeaderData class was expected but instead got {type(block.data)}")
-    
-    tool_name = tool_md.tool.name
-    if tool_name == block.type:
-        header_tool_inst = session.exec(
-            select(header_tool_model.HeaderTool)
-            .where(header_tool_model.HeaderTool.tool_md_id == tool_md.id)
-        ).one()
-        header_tool_inst.text = block.data.text
-        header_tool_inst.level = block.data.level
-        session.add(header_tool_inst)
-        session.commit()
-    
-    else:
-        tool_cls = tool_name_cls_map[tool_name]
-        tool_inst = session.exec(
-            select(tool_cls)
-            .where(tool_cls.tool_md_id == tool_md.id)
-        ).one()
-        session.delete(tool_inst)
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_header_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_header_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_header_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        if type(block.data) != HeaderData:
+            raise ValueError(f"object of HeaderData class was expected but instead got {type(block.data)}")
+
+        tool_name = tool_md.tool.name
+        if tool_name == block.type:
+            header_tool_inst = session.exec(
+                select(header_tool_model.HeaderTool)
+                .where(header_tool_model.HeaderTool.tool_md_id == tool_md.id)
+            ).one()
+            header_tool_inst.text = block.data.text
+            header_tool_inst.level = block.data.level
+            session.add(header_tool_inst)
+            session.commit()
+
+        else:
+            tool_cls = tool_name_cls_map[tool_name]
+            tool_inst = session.exec(
+                select(tool_cls)
+                .where(tool_cls.tool_md_id == tool_md.id)
+            ).one()
+            session.delete(tool_inst)
 
 
 
-        # header_tool_inst = header_tool_model.HeaderTool(
-        #     text= block.data.text,
-        #     level= block.data.level,
-        #     tool_md_id= tool_md.id
-        # )
-        # session.add(header_tool_inst)
-        session, tool_md = update_ToolMD(session=session,
-                                                 tool_md= tool_md,
-                                                 tool_name= block.type,
-                                                 block_id=block.id)
-        session, header_tool_inst = add_header_tool_data(
-            session=session,
-            block=block,
-            tool_md_id= tool_md.id
-        )
-    
-    current_span.add_event("header tool data has been updated in the header tool tbl")
+            # header_tool_inst = header_tool_model.HeaderTool(
+            #     text= block.data.text,
+            #     level= block.data.level,
+            #     tool_md_id= tool_md.id
+            # )
+            # session.add(header_tool_inst)
+            session, tool_md = update_ToolMD(session=session,
+                                                     tool_md= tool_md,
+                                                     tool_name= block.type,
+                                                     block_id=block.id)
+            session, header_tool_inst = add_header_tool_data(
+                session=session,
+                block=block,
+                tool_md_id= tool_md.id
+            )
+
+        current_span.add_event("header tool data has been updated in the header tool tbl")
     return ( session, header_tool_inst)
 
 
-@tracer.start_as_current_span("update_list_tool_data")
+# @tracer.start_as_current_span("update_list_tool_data")
 def update_list_tool_data(session: Session, 
                           block: Block, 
                           tool_md: tool_model.ToolMD
@@ -419,79 +499,88 @@ def update_list_tool_data(session: Session,
                             Session,
                           tool_model.ToolDataModel
                           ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_list_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    if type(block.data) != ListData:
-        raise ValueError(f"object of ListData class was expected but instead got {type(block.data)}")
-    
-    @tracer.start_as_current_span("store_items[update]")
-    def store_items(session: Session, 
-                   item_list: List[ListItem],
-                   lttbl_id: Optional[uuid.UUID],
-                   parent_item_id: Optional[uuid.UUID]):
-        current_span = trace.get_current_span()
-        for idx, item in enumerate(item_list):
-            sequence = idx + 1
-            item_tbl = list_tool_models.Item(
-                lttbl_id= lttbl_id,
-                sequence= sequence,
-                content= item.content,
-                meta= item.meta,
-                parent_item_id= parent_item_id
-            )
-            session.add(item_tbl)
-            if item.items != []:
-                store_items(session, item.items, None, item_tbl.id)
-        current_span.add_event("list items have been stored in the db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_list_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_list_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_list_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        if type(block.data) != ListData:
+            raise ValueError(f"object of ListData class was expected but instead got {type(block.data)}")
 
-    tool_name = tool_md.tool.name
-    if tool_name == block.type:
-        lt_tbl = session.exec(
-            select(list_tool_models.ListToolTbl)
-            .where(list_tool_models.ListToolTbl.tool_md_id == tool_md.id)
-        ).one()
-        items = session.exec(
-            select(list_tool_models.Item)
-            .where(list_tool_models.Item.lttbl_id == lt_tbl.id )
-        ).all()
-        for item in items:
-            session.delete(item)
+        @tracer.start_as_current_span("store_items[update]")
+        def store_items(session: Session, 
+                       item_list: List[ListItem],
+                       lttbl_id: Optional[uuid.UUID],
+                       parent_item_id: Optional[uuid.UUID]):
+            current_span = trace.get_current_span()
+            for idx, item in enumerate(item_list):
+                sequence = idx + 1
+                item_tbl = list_tool_models.Item(
+                    lttbl_id= lttbl_id,
+                    sequence= sequence,
+                    content= item.content,
+                    meta= item.meta,
+                    parent_item_id= parent_item_id
+                )
+                session.add(item_tbl)
+                if item.items != []:
+                    store_items(session, item.items, None, item_tbl.id)
+            current_span.add_event("list items have been stored in the db")
 
-        lt_tbl.style = block.data.style
-        lt_tbl.meta = block.data.meta
-        session.add(lt_tbl)
-        store_items(session, block.data.items,
-                lt_tbl.id,
-                None)
-        session.commit()
-        
-    else: 
-        tool_cls = tool_name_cls_map[tool_name]
-        tool_inst = session.exec(
-            select(tool_cls)
-            .where(tool_cls.tool_md_id == tool_md.id)
-        ).one()
-        session.delete(tool_inst)
+        tool_name = tool_md.tool.name
+        if tool_name == block.type:
+            lt_tbl = session.exec(
+                select(list_tool_models.ListToolTbl)
+                .where(list_tool_models.ListToolTbl.tool_md_id == tool_md.id)
+            ).one()
+            items = session.exec(
+                select(list_tool_models.Item)
+                .where(list_tool_models.Item.lttbl_id == lt_tbl.id )
+            ).all()
+            for item in items:
+                session.delete(item)
 
-        session, tool_md = update_ToolMD(session=session,
-                                                 tool_md= tool_md,
-                                                 tool_name= block.type,
-                                                 block_id=block.id)
-        session, lt_tbl = add_list_tool_data(session=session,
-                           block=block,
-                           tool_md_id=tool_md.id
-                        )
-    
-    current_span.add_event("list tool data has been updated in the list tool tbl")
+            lt_tbl.style = block.data.style
+            lt_tbl.meta = block.data.meta
+            session.add(lt_tbl)
+            store_items(session, block.data.items,
+                    lt_tbl.id,
+                    None)
+            session.commit()
+
+        else: 
+            tool_cls = tool_name_cls_map[tool_name]
+            tool_inst = session.exec(
+                select(tool_cls)
+                .where(tool_cls.tool_md_id == tool_md.id)
+            ).one()
+            session.delete(tool_inst)
+
+            session, tool_md = update_ToolMD(session=session,
+                                                     tool_md= tool_md,
+                                                     tool_name= block.type,
+                                                     block_id=block.id)
+            session, lt_tbl = add_list_tool_data(session=session,
+                               block=block,
+                               tool_md_id=tool_md.id
+                            )
+
+        current_span.add_event("list tool data has been updated in the list tool tbl")
     return (session, lt_tbl)
 
 
-@tracer.start_as_current_span("update_paragraph_tool_data")
+# @tracer.start_as_current_span("update_paragraph_tool_data")
 def update_paragraph_tool_data(session: Session,
                                block: Block, 
                           tool_md: tool_model.ToolMD
@@ -499,49 +588,58 @@ def update_paragraph_tool_data(session: Session,
                             Session,
                           tool_model.ToolDataModel
                           ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_paragraph_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    if type(block.data) != ParagraphData:
-        raise ValueError(f"object of ParagraphData class was expected but instead got {type(block.data)}")
-    tool_md_id = tool_md.id
-    if type(tool_md_id) != uuid.UUID:
-        ValueError(f"tool md is not of uuid type : {tool_md_id}")
-    tool_name = tool_md.tool.name
-    with open("update_paragraph.log", 'a') as f:
-        f.write(f"tool name: {tool_name}, block.data: {type(block.data)}")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_paragraph_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_paragraph_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_paragraph_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        if type(block.data) != ParagraphData:
+            raise ValueError(f"object of ParagraphData class was expected but instead got {type(block.data)}")
+        tool_md_id = tool_md.id
+        if type(tool_md_id) != uuid.UUID:
+            ValueError(f"tool md is not of uuid type : {tool_md_id}")
+        tool_name = tool_md.tool.name
+        with open("update_paragraph.log", 'a') as f:
+            f.write(f"tool name: {tool_name}, block.data: {type(block.data)}")
 
-    if tool_name == block.type:
-        p_tbl = session.exec(
-            select(paragraph_tool_model.ParagraphTool)
-            .where(paragraph_tool_model.ParagraphTool.tool_md_id == tool_md.id)
-        ).one()
-        p_tbl.text = block.data.text
-        session.add(p_tbl)
-        session.commit()
-    
-    else:
-        tool_cls = tool_name_cls_map[tool_name]
-        tool_inst = session.exec(
-            select(tool_cls)
-            .where(tool_cls.tool_md_id == tool_md.id)
-        ).one()
-        session.delete(tool_inst)
+        if tool_name == block.type:
+            p_tbl = session.exec(
+                select(paragraph_tool_model.ParagraphTool)
+                .where(paragraph_tool_model.ParagraphTool.tool_md_id == tool_md.id)
+            ).one()
+            p_tbl.text = block.data.text
+            session.add(p_tbl)
+            session.commit()
 
-        session, tool_md = update_ToolMD(session=session,
-                                                 tool_md= tool_md,
-                                                 tool_name= block.type,
-                                                 block_id=block.id)
-        session, p_tbl = add_paragraph_tool_data(session, block, tool_md.id)
-    current_span.add_event("paragraph tool data has been updated")
+        else:
+            tool_cls = tool_name_cls_map[tool_name]
+            tool_inst = session.exec(
+                select(tool_cls)
+                .where(tool_cls.tool_md_id == tool_md.id)
+            ).one()
+            session.delete(tool_inst)
+
+            session, tool_md = update_ToolMD(session=session,
+                                                     tool_md= tool_md,
+                                                     tool_name= block.type,
+                                                     block_id=block.id)
+            session, p_tbl = add_paragraph_tool_data(session, block, tool_md.id)
+        current_span.add_event("paragraph tool data has been updated")
     return (session, p_tbl)
 
 
-@tracer.start_as_current_span("update_quote_tool_data")
+# @tracer.start_as_current_span("update_quote_tool_data")
 def update_quote_tool_data(session: Session,
                            block: Block, 
                           tool_md: tool_model.ToolMD
@@ -549,50 +647,59 @@ def update_quote_tool_data(session: Session,
                             Session,
                           tool_model.ToolDataModel
                           ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_quote_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    if type(block.data) != QuoteData:
-        raise ValueError(f"object of QuoteData class was expected but instead got {type(block.data)}")
-    
-    tool_name = tool_md.tool.name
-    if tool_name == block.type:
-        quote_tbl = session.exec(
-            select(quote_tool_model.QuoteTool)
-            .where(quote_tool_model.QuoteTool.tool_md_id == tool_md.id)
-        ).one()
-        quote_tbl.text = block.data.text
-        quote_tbl.caption = block.data.caption
-        quote_tbl.alignment = block.data.alignment
-        session.add(quote_tbl)
-        session.commit()
-    
-    else:
-        tool_cls = tool_name_cls_map[tool_name]
-        tool_inst = session.exec(
-            select(tool_cls)
-            .where(tool_cls.tool_md_id == tool_md.id)
-        ).one()
-        session.delete(tool_inst)
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_quote_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_quote_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_quote_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        if type(block.data) != QuoteData:
+            raise ValueError(f"object of QuoteData class was expected but instead got {type(block.data)}")
 
-        session, tool_md = update_ToolMD(session=session,
-                                                 tool_md= tool_md,
-                                                 tool_name= block.type,
-                                                 block_id=block.id)
-        session, quote_tbl = add_quote_tool_data(
-            session,
-            block,
-            tool_md.id
-        )
-    current_span.add_event("quote tool data has been updated in quote tool tbl")
+        tool_name = tool_md.tool.name
+        if tool_name == block.type:
+            quote_tbl = session.exec(
+                select(quote_tool_model.QuoteTool)
+                .where(quote_tool_model.QuoteTool.tool_md_id == tool_md.id)
+            ).one()
+            quote_tbl.text = block.data.text
+            quote_tbl.caption = block.data.caption
+            quote_tbl.alignment = block.data.alignment
+            session.add(quote_tbl)
+            session.commit()
+
+        else:
+            tool_cls = tool_name_cls_map[tool_name]
+            tool_inst = session.exec(
+                select(tool_cls)
+                .where(tool_cls.tool_md_id == tool_md.id)
+            ).one()
+            session.delete(tool_inst)
+
+            session, tool_md = update_ToolMD(session=session,
+                                                     tool_md= tool_md,
+                                                     tool_name= block.type,
+                                                     block_id=block.id)
+            session, quote_tbl = add_quote_tool_data(
+                session,
+                block,
+                tool_md.id
+            )
+        current_span.add_event("quote tool data has been updated in quote tool tbl")
     return (session, quote_tbl)
 
 
-@tracer.start_as_current_span("update_table_tool_data")
+# @tracer.start_as_current_span("update_table_tool_data")
 def update_table_tool_data(session: Session,
                            block: Block, 
                           tool_md: tool_model.ToolMD
@@ -600,375 +707,500 @@ def update_table_tool_data(session: Session,
                             Session,
                           tool_model.ToolDataModel
                           ]:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-                                   package="dependencies",
-                                   module="editorjs_data_store",
-                                   func_name="update_table_tool_data"
-                                ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    if type(block.data) != TableData:
-        raise ValueError(f"object of TableData class was expected but instead got {type(block.data)}")
-    
-    tool_name = tool_md.tool.name
-    if tool_name == block.type:
-        tt_tbl = session.exec(
-            select(table_tool_model.TableTool)
-            .where(table_tool_model.TableTool.tool_md_id == tool_md.id)
-        ).one()
-        tt_tbl.content = block.data.content
-        session.add(tt_tbl)
-        session.commit()
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #                                package="dependencies",
+    #                                module="editorjs_data_store",
+    #                                func_name="update_table_tool_data"
+    #                             ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("update_table_tool_data",
+                                      attributes={
+                                          **origination_(
+                                           package="dependencies",
+                                           module="editorjs_data_store",
+                                           func_name="update_table_tool_data"
+                                        ),
+                                        "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        if type(block.data) != TableData:
+            raise ValueError(f"object of TableData class was expected but instead got {type(block.data)}")
 
-    else:
-        tool_cls = tool_name_cls_map[tool_name]
-        tool_inst = session.exec(
-            select(tool_cls)
-            .where(tool_cls.tool_md_id == tool_md.id)
-        ).one()
-        session.delete(tool_inst)
+        tool_name = tool_md.tool.name
+        if tool_name == block.type:
+            tt_tbl = session.exec(
+                select(table_tool_model.TableTool)
+                .where(table_tool_model.TableTool.tool_md_id == tool_md.id)
+            ).one()
+            tt_tbl.content = block.data.content
+            session.add(tt_tbl)
+            session.commit()
 
-        session, tool_md = update_ToolMD(session=session,
-                                                 tool_md= tool_md,
-                                                 tool_name= block.type,
-                                                 block_id=block.id)
-        session, tt_tbl = add_table_tool_data(
-            session,
-            block,
-            tool_md.id
-        )
-    current_span.add_event("table tool data has been updated in the table tool tbl")
+        else:
+            tool_cls = tool_name_cls_map[tool_name]
+            tool_inst = session.exec(
+                select(tool_cls)
+                .where(tool_cls.tool_md_id == tool_md.id)
+            ).one()
+            session.delete(tool_inst)
+
+            session, tool_md = update_ToolMD(session=session,
+                                                     tool_md= tool_md,
+                                                     tool_name= block.type,
+                                                     block_id=block.id)
+            session, tt_tbl = add_table_tool_data(
+                session,
+                block,
+                tool_md.id
+            )
+        current_span.add_event("table tool data has been updated in the table tool tbl")
     return (session, tt_tbl)
 
 
-@tracer.start_as_current_span("delete_tool_md")
+# @tracer.start_as_current_span("delete_tool_md")
 def delete_tool_md(session: Session,
                    tool_md: tool_model.ToolMD):
     # tool_md = session.get(tool_model.ToolMD, tool_md_id)
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_tool_md"
-    ))
-    current_span.set_attribute("tool_md.id", str(tool_md.id))
-    session.delete(tool_md)
-    current_span.add_event("tool_md has been deleted from the session")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_tool_md"
+    # ))
+    # current_span.set_attribute("tool_md.id", str(tool_md.id))
+    with tracer.start_as_current_span("delete_tool_md",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_tool_md"
+                                            ),
+                                            "tool_md.id": str(tool_md.id)
+                                      }) as current_span:
+        session.delete(tool_md)
+        current_span.add_event("tool_md has been deleted from the session")
     return session
 
 
-@tracer.start_as_current_span("delete_code_tool_data")
+# @tracer.start_as_current_span("delete_code_tool_data")
 def delete_code_tool_data(session: Session,
                           block_id: str
                           ) -> Session:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_code_tool_data"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id == block_id)
-    ).one()
-    tool_name = session.get(tool_model.Tool, 
-                            tool_md.tool_id
-                            ).name
-    
-    if tool_name != "code":
-        raise ValueError(f"tool name is invalid. It should be 'code' but instead it is {tool_name}")
-    
-    ct_mdl = session.exec(
-        select(code_tool_model.CodeTool)
-        .where(code_tool_model.CodeTool.tool_md_id == tool_md.id)
-    ).one()
-    session = delete_tool_md(session, tool_md)
-    
-    session.delete(ct_mdl)
-    session.commit()
-    current_span.add_event("code tool data has been deleted from the db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_code_tool_data"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("delete_code_tool_data",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_code_tool_data"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id == block_id)
+        ).one()
+        tool_name = session.get(tool_model.Tool, 
+                                tool_md.tool_id
+                                ).name
+
+        if tool_name != "code":
+            raise ValueError(f"tool name is invalid. It should be 'code' but instead it is {tool_name}")
+
+        ct_mdl = session.exec(
+            select(code_tool_model.CodeTool)
+            .where(code_tool_model.CodeTool.tool_md_id == tool_md.id)
+        ).one()
+        session = delete_tool_md(session, tool_md)
+
+        session.delete(ct_mdl)
+        session.commit()
+        current_span.add_event("code tool data has been deleted from the db")
     return session
 
 
-@tracer.start_as_current_span("delete_header_tool_data")
+# @tracer.start_as_current_span("delete_header_tool_data")
 def delete_header_tool_data(session: Session,
                             block_id: str) -> Session:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_header_tool_data"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id == block_id)
-    ).one()
-    tool_name = session.get(tool_model.Tool, 
-                            tool_md.tool_id
-                            ).name
-    
-    if tool_name != "header":
-        raise ValueError(f"tool name is invalid. It should be 'header' but instead it is {tool_name}")
-    
-    ht_mdl = session.exec(
-        select(header_tool_model.HeaderTool)
-        .where(header_tool_model.HeaderTool.tool_md_id == tool_md.id)
-    ).one()
-    session = delete_tool_md(session, tool_md)
-    
-    session.delete(ht_mdl)
-    session.commit()
-    current_span.add_event("header tool data has been deleted from the tbl")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_header_tool_data"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("delete_header_tool_data",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_header_tool_data"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id == block_id)
+        ).one()
+        tool_name = session.get(tool_model.Tool, 
+                                tool_md.tool_id
+                                ).name
+
+        if tool_name != "header":
+            raise ValueError(f"tool name is invalid. It should be 'header' but instead it is {tool_name}")
+
+        ht_mdl = session.exec(
+            select(header_tool_model.HeaderTool)
+            .where(header_tool_model.HeaderTool.tool_md_id == tool_md.id)
+        ).one()
+        session = delete_tool_md(session, tool_md)
+
+        session.delete(ht_mdl)
+        session.commit()
+        current_span.add_event("header tool data has been deleted from the tbl")
     return session
 
 
-@tracer.start_as_current_span("delete_list_tool_data")
+# @tracer.start_as_current_span("delete_list_tool_data")
 def delete_list_tool_data(session: Session,
                           block_id: str) -> Session:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_list_tool_data"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id == block_id)
-    ).one()
-    tool_name = session.get(tool_model.Tool, 
-                            tool_md.tool_id
-                            ).name
-    
-    if tool_name != "list":
-        raise ValueError(f"tool name is invalid. It should be 'list' but instead it is {tool_name}")
-    
-    ltt_mdl = session.exec(
-        select(list_tool_models.ListToolTbl)
-        .where(list_tool_models.ListToolTbl.tool_md_id == tool_md.id)
-    ).one()
-    items = session.exec(
-        select(list_tool_models.Item)
-        .where(list_tool_models.Item.lttbl_id == ltt_mdl.id)
-    ).all()
-    session = delete_tool_md(session, tool_md)
-    
-    session.delete(ltt_mdl)
-    for item in items:
-        session.delete(item) 
-    session.commit()
-    current_span.add_event("list tool data has been deleted from the tbl")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_list_tool_data"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("delete_list_tool_data",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_list_tool_data"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id == block_id)
+        ).one()
+        tool_name = session.get(tool_model.Tool, 
+                                tool_md.tool_id
+                                ).name
+
+        if tool_name != "list":
+            raise ValueError(f"tool name is invalid. It should be 'list' but instead it is {tool_name}")
+
+        ltt_mdl = session.exec(
+            select(list_tool_models.ListToolTbl)
+            .where(list_tool_models.ListToolTbl.tool_md_id == tool_md.id)
+        ).one()
+        items = session.exec(
+            select(list_tool_models.Item)
+            .where(list_tool_models.Item.lttbl_id == ltt_mdl.id)
+        ).all()
+        session = delete_tool_md(session, tool_md)
+
+        session.delete(ltt_mdl)
+        for item in items:
+            session.delete(item) 
+        session.commit()
+        current_span.add_event("list tool data has been deleted from the tbl")
     return session
 
 
-@tracer.start_as_current_span("delete_paragraph_tool_data")
+# @tracer.start_as_current_span("delete_paragraph_tool_data")
 def delete_paragraph_tool_data(session: Session,
                           block_id: str) -> Session:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_paragraph_tool_data"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id == block_id)
-    ).one()
-    tool_name = session.get(tool_model.Tool, 
-                            tool_md.tool_id
-                            ).name
-    
-    if tool_name != "paragraph":
-        raise ValueError(f"tool name is invalid. It should be 'paragraph' but instead it is {tool_name}")
-    
-    pt_mdl = session.exec(
-        select(paragraph_tool_model.ParagraphTool)
-        .where(paragraph_tool_model.ParagraphTool.tool_md_id == tool_md.id)
-    ).one()
-    session = delete_tool_md(session, tool_md)
-    
-    session.delete(pt_mdl)
-    session.commit()
-    current_span.add_event("paragraph tool data has been deleted from the db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_paragraph_tool_data"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("delete_paragraph_tool_data",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_paragraph_tool_data"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id == block_id)
+        ).one()
+        tool_name = session.get(tool_model.Tool, 
+                                tool_md.tool_id
+                                ).name
+
+        if tool_name != "paragraph":
+            raise ValueError(f"tool name is invalid. It should be 'paragraph' but instead it is {tool_name}")
+
+        pt_mdl = session.exec(
+            select(paragraph_tool_model.ParagraphTool)
+            .where(paragraph_tool_model.ParagraphTool.tool_md_id == tool_md.id)
+        ).one()
+        session = delete_tool_md(session, tool_md)
+
+        session.delete(pt_mdl)
+        session.commit()
+        current_span.add_event("paragraph tool data has been deleted from the db")
     return session
 
-@tracer.start_as_current_span("delete_quote_tool_data")
+# @tracer.start_as_current_span("delete_quote_tool_data")
 def delete_quote_tool_data(session: Session,
                           block_id: str) -> Session:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_quote_tool_data"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id == block_id)
-    ).one()
-    tool_name = session.get(tool_model.Tool, 
-                            tool_md.tool_id
-                            ).name
-    
-    if tool_name != "quote":
-        raise ValueError(f"tool name is invalid. It should be 'quote' but instead it is {tool_name}")
-    
-    qt_mdl = session.exec(
-        select(quote_tool_model.QuoteTool)
-        .where(quote_tool_model.QuoteTool.tool_md_id == tool_md.id)
-    ).one()
-    session = delete_tool_md(session, tool_md)
-    
-    session.delete(qt_mdl)
-    session.commit()
-    current_span.add_event("quote tool has been deleted from the db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_quote_tool_data"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("delete_quote_tool_data",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_quote_tool_data"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id == block_id)
+        ).one()
+        tool_name = session.get(tool_model.Tool, 
+                                tool_md.tool_id
+                                ).name
+
+        if tool_name != "quote":
+            raise ValueError(f"tool name is invalid. It should be 'quote' but instead it is {tool_name}")
+
+        qt_mdl = session.exec(
+            select(quote_tool_model.QuoteTool)
+            .where(quote_tool_model.QuoteTool.tool_md_id == tool_md.id)
+        ).one()
+        session = delete_tool_md(session, tool_md)
+
+        session.delete(qt_mdl)
+        session.commit()
+        current_span.add_event("quote tool has been deleted from the db")
     return session
 
 
-@tracer.start_as_current_span("delete_table_tool_data")
+# @tracer.start_as_current_span("delete_table_tool_data")
 def delete_table_tool_data(session: Session,
                           block_id: str) -> Session:
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_table_tool_data"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id == block_id)
-    ).one()
-    tool_name = session.get(tool_model.Tool, 
-                            tool_md.tool_id
-                            ).name
-    
-    if tool_name != "table":
-        raise ValueError(f"tool name is invalid. It should be 'table' but instead it is {tool_name}")
-    
-    tt_mdl = session.exec(
-        select(table_tool_model.TableTool)
-        .where(table_tool_model.TableTool.tool_md_id == tool_md.id)
-    ).one()
-    session = delete_tool_md(session, tool_md)
-    
-    session.delete(tt_mdl)
-    session.commit()
-    current_span.add_event("table tool data has been deleted from the db")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_table_tool_data"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("delete_table_tool_data",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_table_tool_data"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id == block_id)
+        ).one()
+        tool_name = session.get(tool_model.Tool, 
+                                tool_md.tool_id
+                                ).name
+
+        if tool_name != "table":
+            raise ValueError(f"tool name is invalid. It should be 'table' but instead it is {tool_name}")
+
+        tt_mdl = session.exec(
+            select(table_tool_model.TableTool)
+            .where(table_tool_model.TableTool.tool_md_id == tool_md.id)
+        ).one()
+        session = delete_tool_md(session, tool_md)
+
+        session.delete(tt_mdl)
+        session.commit()
+        current_span.add_event("table tool data has been deleted from the db")
     return session
 
 
-@tracer.start_as_current_span("get_toolmd_ifexists")
+# @tracer.start_as_current_span("get_toolmd_ifexists")
 def get_toolmd_ifexists(block_id: str) -> Optional[tool_model.ToolMD] \
         | MultipleResultsFound:
     """ 
     This function checks if the block data exists in the db or not.
     """
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="get_toolmd_ifexists"
-    ))
-    current_span.set_attribute("block.id", block_id)
-    session = next(get_session())
-    try:
-        tool_md = session.exec(
-            select(tool_model.ToolMD)
-            .where(tool_model.ToolMD.block_id == block_id)
-        ).one()
-        '''
-        the MultipleResultsFound exception is purposefully
-        not handled here as we want that error to be thrown.
-        Because, if that error is caused that means there is
-        a serious consistency problem in our db.
-        '''
-    except NoResultFound:
-        return None 
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="get_toolmd_ifexists"
+    # ))
+    # current_span.set_attribute("block.id", block_id)
+    with tracer.start_as_current_span("get_toolmd_ifexists",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="get_toolmd_ifexists"
+                                            ),
+                                            "block.id": block_id
+                                      }) as current_span:
+        session = next(get_session())
+        try:
+            tool_md = session.exec(
+                select(tool_model.ToolMD)
+                .where(tool_model.ToolMD.block_id == block_id)
+            ).one()
+            '''
+            the MultipleResultsFound exception is purposefully
+            not handled here as we want that error to be thrown.
+            Because, if that error is caused that means there is
+            a serious consistency problem in our db.
+            '''
+        except NoResultFound:
+            return None 
     
     return tool_md
 
 
-@tracer.start_as_current_span("get_prev_toolmd")
-def get_prev_toolmd(block_ids: List[str], article_id: uuid.UUID, session: Session) -> List[tool_model.ToolMD]:
+# @tracer.start_as_current_span("get_prev_toolmd")
+def get_prev_toolmd(block_ids: List[str], 
+                    article_id: uuid.UUID, 
+                    session: Session
+                    ) -> List[tool_model.ToolMD]:
     '''
     This should return all the toolmd for which 
     blocks does not exist in the frontend.
     '''
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="get_prev_toolmd"
-    ))
-    current_span.set_attribute("block_ids", block_ids)
-    current_span.set_attribute("article.id", str(article_id))
-    tool_md = session.exec(
-        select(tool_model.ToolMD)
-        .where(tool_model.ToolMD.block_id.not_in(block_ids))
-        .where(tool_model.ToolMD.article_id == article_id)
-    ).all()
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="get_prev_toolmd"
+    # ))
+    # current_span.set_attribute("block_ids", block_ids)
+    # current_span.set_attribute("article.id", str(article_id))
+    with tracer.start_as_current_span("get_prev_toolmd",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="get_prev_toolmd"
+                                            ),
+                                            "block.id[]": block_ids,
+                                            "article.id": str(article_id)
+                                      }) as current_span:
+        tool_md = session.exec(
+            select(tool_model.ToolMD)
+            .where(tool_model.ToolMD.block_id.not_in(block_ids))
+            .where(tool_model.ToolMD.article_id == article_id)
+        ).all()
     return tool_md
 
 
-@tracer.start_as_current_span("delete_inexisting_toolmd")
+# @tracer.start_as_current_span("delete_inexisting_toolmd")
 def delete_inexisting_toolmd(block_ids: List[str], article_id: uuid.UUID) :
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="delete_inexisting_toolmd"
-    ))
-    current_span.set_attribute("block_ids", block_ids)
-    current_span.set_attribute("article.id", str(article_id))
-    session = next(get_session())
-    tool_mds = get_prev_toolmd(block_ids, article_id, session)
-    for tool_md in tool_mds:
-        tool_name = session.get(tool_model.Tool, 
-                                    tool_md.tool_id).name
-        delete_func = delete_func_map[tool_name]
-        session = delete_func(session, tool_md.block_id)
-        session.delete(tool_md)
-    session.commit()
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="delete_inexisting_toolmd"
+    # ))
+    # current_span.set_attribute("block_ids", block_ids)
+    # current_span.set_attribute("article.id", str(article_id))
+    with tracer.start_as_current_span("delete_inexisting_toolmd",
+                                      attributes= {
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="delete_inexisting_toolmd"
+                                            ),
+                                            "block.id[]": block_ids,
+                                            "article.id": str(article_id)
+                                      }) as current_span:
+        session = next(get_session())
+        tool_mds = get_prev_toolmd(block_ids, article_id, session)
+        for tool_md in tool_mds:
+            tool_name = session.get(tool_model.Tool, 
+                                        tool_md.tool_id).name
+            delete_func = delete_func_map[tool_name]
+            session = delete_func(session, tool_md.block_id)
+            session.delete(tool_md)
+        session.commit()
 
 
-@tracer.start_as_current_span("update_tool_md_seq")
+# @tracer.start_as_current_span("update_tool_md_seq")
 def update_tool_md_seq(session: Session, tool_md_id: uuid.UUID, seq: int):
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="update_tool_md_seq"
-    ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
-    current_span.set_attribute("seq", seq)
-    tool_md = session.get(tool_model.ToolMD, tool_md_id)
-    tool_md.sequence = seq 
-    session.add(tool_md)
-    current_span.add_event("tool_md sequence has been updated in the tool_md tbl")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="update_tool_md_seq"
+    # ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
+    # current_span.set_attribute("seq", seq)
+    with tracer.start_as_current_span("update_tool_md_seq",
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="update_tool_md_seq"
+                                            ),
+                                            "tool_md.id": str(tool_md_id),
+                                            "seq": seq
+                                      }) as current_span:
+        tool_md = session.get(tool_model.ToolMD, tool_md_id)
+        tool_md.sequence = seq 
+        session.add(tool_md)
+        current_span.add_event("tool_md sequence has been updated in the tool_md tbl")
     return session
 
-@tracer.start_as_current_span("update_tool_md_time_n_ver")
+# @tracer.start_as_current_span("update_tool_md_time_n_ver")
 def update_tool_md_time_n_ver(session: Session, 
                             tool_md_id: uuid.UUID, 
                             time: datetime, version: str):
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="update_tool_md_time_n_ver"
-    ))
-    current_span.set_attribute("tool_md.id", str(tool_md_id))
-    current_span.set_attribute("time", str(time))
-    current_span.set_attribute("version", version)
-    tool_md = session.get(tool_model.ToolMD, tool_md_id)
-    tool_md.time = time 
-    tool_md.version = version
-    session.add(tool_md)
-    current_span.add_event("tool_md has been updated with new time and version")
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="update_tool_md_time_n_ver"
+    # ))
+    # current_span.set_attribute("tool_md.id", str(tool_md_id))
+    # current_span.set_attribute("time", str(time))
+    # current_span.set_attribute("version", version)
+    with tracer.start_as_current_span("update_tool_md_time_n_ver",
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="update_tool_md_time_n_ver"
+                                            ),
+                                            "tool_md.id": str(tool_md_id),
+                                            "time": str(time),
+                                            "version": version
+                                      }) as current_span:
+        tool_md = session.get(tool_model.ToolMD, tool_md_id)
+        tool_md.time = time 
+        tool_md.version = version
+        session.add(tool_md)
+        current_span.add_event("tool_md has been updated with new time and version")
     return session
 
 
@@ -1000,7 +1232,7 @@ delete_func_map = {
 }
 
 
-@tracer.start_as_current_span("store_editorjs_data")
+# @tracer.start_as_current_span("store_editorjs_data")
 def store_editorjs_data(editorjs_data: EditorJSSessionData) :
     
     # article id will be supplied from the frontend
@@ -1053,59 +1285,67 @@ def store_editorjs_data(editorjs_data: EditorJSSessionData) :
         3. delete the block ids from the table with same sequence 
         where the block id is not equal to the one in the blocks
     '''
-    current_span = trace.get_current_span()
-    current_span.set_attributes(origination_(
-        package="dependencies",
-        module="editorjs_data_store",
-        func_name="store_editorjs_data"
-    ))
-    time = datetime.fromtimestamp(editorjs_data.time / 1000)
-    version = editorjs_data.version
-    blocks = editorjs_data.blocks
-    tool_md_exists = [ get_toolmd_ifexists(block.id) for block in blocks]
-    article_id = uuid.UUID(editorjs_data.article_id)
+    # current_span = trace.get_current_span()
+    # current_span.set_attributes(origination_(
+    #     package="dependencies",
+    #     module="editorjs_data_store",
+    #     func_name="store_editorjs_data"
+    # ))
+    with tracer.start_as_current_span("store_editorjs_data",
+                                      attributes={
+                                          **origination_(
+                                            package="dependencies",
+                                            module="editorjs_data_store",
+                                            func_name="store_editorjs_data"
+                                            )
+                                      }) as current_span:
+        time = datetime.fromtimestamp(editorjs_data.time / 1000)
+        version = editorjs_data.version
+        blocks = editorjs_data.blocks
+        tool_md_exists = [ get_toolmd_ifexists(block.id) for block in blocks]
+        article_id = uuid.UUID(editorjs_data.article_id)
 
-    for idx, tool_md in enumerate(tool_md_exists):
-        if tool_md:
-            # update the existing data
-            block = blocks[idx]
-            block.sequence = idx + 1
-            tool_type = block.type
-            func = update_func_map[tool_type]
-            session = next(get_session())
-            # tool_md.sequence = block.sequence
-            # session.add(tool_md)
-            update_tool_md_seq(session, tool_md.id, block.sequence)
-            update_tool_md_time_n_ver(session, tool_md.id, time, version)
-            s, tool_data_mdl = func(session, block, tool_md)
-        else:
-            # add new data
-            block = blocks[idx]
-            block.sequence = idx + 1
-            tool_type = block.type
-            func = func_map[tool_type]
-            session = next(get_session())
-            s, tool_md = add_tool_md(session, block, article_id, time, version)
-            print(f"tool md data: {tool_md}")
-            s, tool_data_mdl = func(s, block, tool_md.id)
-    
+        for idx, tool_md in enumerate(tool_md_exists):
+            if tool_md:
+                # update the existing data
+                block = blocks[idx]
+                block.sequence = idx + 1
+                tool_type = block.type
+                func = update_func_map[tool_type]
+                session = next(get_session())
+                # tool_md.sequence = block.sequence
+                # session.add(tool_md)
+                update_tool_md_seq(session, tool_md.id, block.sequence)
+                update_tool_md_time_n_ver(session, tool_md.id, time, version)
+                s, tool_data_mdl = func(session, block, tool_md)
+            else:
+                # add new data
+                block = blocks[idx]
+                block.sequence = idx + 1
+                tool_type = block.type
+                func = func_map[tool_type]
+                session = next(get_session())
+                s, tool_md = add_tool_md(session, block, article_id, time, version)
+                print(f"tool md data: {tool_md}")
+                s, tool_data_mdl = func(s, block, tool_md.id)
 
 
-    # for block in blocks:
-    #     session = next(get_session())
-    #     tool_mds = session.exec(
-    #         select(tool_model.ToolMD)
-    #         .where(tool_model.ToolMD.article_id == article_id)
-    #         .where(tool_model.ToolMD.sequence == block.sequence)
-    #         .where(tool_model.ToolMD.block_id != block.id)
-    #     ).all()
-    #     for tool_md in tool_mds:
-    #         tool_name = session.get(tool_model.Tool, 
-    #                                 tool_md.tool_id).name
-    #         delete_func = delete_func_map[tool_name]
-    #         session = delete_func(session, tool_md.block_id)
-    block_ids = [block.id for block in blocks]
-    delete_inexisting_toolmd(block_ids, article_id)
+
+        # for block in blocks:
+        #     session = next(get_session())
+        #     tool_mds = session.exec(
+        #         select(tool_model.ToolMD)
+        #         .where(tool_model.ToolMD.article_id == article_id)
+        #         .where(tool_model.ToolMD.sequence == block.sequence)
+        #         .where(tool_model.ToolMD.block_id != block.id)
+        #     ).all()
+        #     for tool_md in tool_mds:
+        #         tool_name = session.get(tool_model.Tool, 
+        #                                 tool_md.tool_id).name
+        #         delete_func = delete_func_map[tool_name]
+        #         session = delete_func(session, tool_md.block_id)
+        block_ids = [block.id for block in blocks]
+        delete_inexisting_toolmd(block_ids, article_id)
             
     return editorjs_data
     # pass 


### PR DESCRIPTION
I have changed the span creation from creation via decorator to creation via context manager. This change has been made so that attributes to the span can be added at span creation. This will ease the process of sampling as only the data which is added to the span while the span creation is used for head sampling. This change is made because remote sampling only provides head sampling.